### PR TITLE
make it possible to select an older spigot version, to verify our code compiles against older versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.number>UNKNOWN</project.build.number>
         <project.build.version>${project.version}</project.build.version>
+        <spigot.version>1.18.1-R0.1-SNAPSHOT</spigot.version>
     </properties>
 
     <repositories>
@@ -34,7 +35,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>${spigot.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
With this change, we can select any spigot version on compile time, to verify it compiles against an older version (this could also be used in actions to automate this later on)

For example, we could use the following command to compile against 1.17.1:
`mvn clean package -Dspigot.version=1.17.1-R0.1-SNAPSHOT`

Let me know what you think.